### PR TITLE
Adds scripts/update_assets.py and groundcontrol_assets usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,5 +161,8 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# GroundControl assets
+source/groundcontrol_assets/data
+
 # archived files
 ARCHIVE/

--- a/scripts/update_assets.py
+++ b/scripts/update_assets.py
@@ -1,0 +1,205 @@
+import boto3
+import botocore
+from botocore import UNSIGNED
+from botocore.config import Config
+import os
+import tqdm
+from groundcontrol_assets import GROUNDCONTROL_ASSETS_DATA_DIR
+from dataclasses import dataclass, MISSING
+
+@dataclass
+class S3BucketCfg:
+    bucket_name: str = MISSING
+    region_name: str = MISSING
+    s3_folder_path: str = MISSING
+    target_local_path: str = MISSING
+    my_access_key_ID: str = None
+    my_secret_key: str = None
+
+@dataclass
+class RobotAssetBucketCfg(S3BucketCfg):
+    bucket_name: str = "omniverse-content-production"
+    region_name: str = "us-west-2"
+    s3_folder_path: str = "Assets/Isaac/4.5/Isaac/Robots/BostonDynamics/spot/spot.usd"
+    target_local_path: str = f"{GROUNDCONTROL_ASSETS_DATA_DIR}/Robots/"
+
+@dataclass
+class WorldAssetBucketCfg(S3BucketCfg):
+    bucket_name: str = "arl-tiamat-data"
+    region_name: str = "us-east-1"
+    s3_folder_path: str = "Collected_GQ_lite/"
+    target_local_path: str = f"{GROUNDCONTROL_ASSETS_DATA_DIR}/Worlds/"
+    my_access_key_ID: str = None 
+    my_secret_key: str = None 
+
+    def __post_init__(self):
+        # check if my_access_key is missing
+        if not self.my_access_key_ID:
+            print("Missing Access Key ID in config dataclass. Add manually or enter here: \n")
+            self.my_access_key_ID = input("Enter your AWS Access Key ID: ")
+        if not self.my_secret_key:
+            print("Missing Secret Access Key in config dataclass. Add manually or enter here: \n")
+            self.my_secret_key = input("Enter your AWS Secret Access Key: ")
+
+def download_s3_folder(bucket_name, region_name, s3_folder, local_dir, aws_access_key_id=None, aws_secret_access_key=None):
+    """
+    Downloads an entire folder (prefix) from an S3 bucket.
+
+    Args:
+        bucket_name: The name of the S3 bucket.
+        region_name (optional): The AWS region.
+        s3_folder: The folder (prefix) within the S3 bucket to download.  e.g., 'my_folder/'
+                    If you want to download the entire bucket, use an empty string ('').
+        local_dir: The local directory where the folder's contents should be saved.
+        aws_access_key_id: Your AWS access key ID.
+        aws_secret_access_key: Your AWS secret access key.
+
+    Returns:
+        True if the download was successful (or if there was nothing to download), False otherwise.
+
+    Raises:
+        ValueError: If bucket_name is empty, or local_dir doesn't exist.
+        botocore.exceptions.ClientError: If there are any issues with S3 access.
+        botocore.exceptions.NoCredentialsError: If AWS credentials cannot be found.
+        Exception: For other unforeseen errors.
+
+    """
+
+    if not bucket_name:
+        raise ValueError("Bucket name cannot be empty.")
+
+    if not os.path.isdir(local_dir):
+        os.makedirs(local_dir, exist_ok=True)
+
+    try:
+        # Create an S3 client (same credential handling as before)
+        if aws_access_key_id and aws_secret_access_key:
+            s3 = boto3.client('s3', aws_access_key_id=aws_access_key_id,
+                              aws_secret_access_key=aws_secret_access_key,
+                              region_name=region_name)
+        else:
+            s3 = boto3.client('s3', region_name=region_name)
+
+        # List objects within the specified folder (prefix)
+        paginator = s3.get_paginator('list_objects_v2')
+        pages = paginator.paginate(Bucket=bucket_name, Prefix=s3_folder)
+
+        downloaded_something = False
+
+        # First iterate over pages and objects to get the total size of all objects
+        total_size_to_download = 0
+        for page in pages:
+            if 'Contents' in page:
+                total_page_size = sum(obj['Size'] for obj in page['Contents'])
+                total_size_to_download += total_page_size
+        print(total_size_to_download)
+
+        with tqdm.tqdm(total=total_size_to_download, unit="B", unit_scale=True, desc="Graces Quarters Assets") as pbar:
+            for page in pages:
+                if 'Contents' in page:  # Check if the page has any objects
+                    for obj in page['Contents']:
+                        s3_key = obj['Key']
+                        # Construct the local file path, preserving the folder structure
+                        relative_path = os.path.relpath(s3_key, s3_folder)
+                        local_file_path = os.path.join(local_dir, relative_path)
+
+                        # Create necessary directories
+                        os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
+
+                        # Download the file
+                        try:
+                            s3.download_file(
+                                bucket_name,
+                                s3_key,
+                                local_file_path,
+                                Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
+                            )
+                            #print(f"Downloaded: {s3_key} -> {local_file_path}")
+                            downloaded_something = True
+                        except botocore.exceptions.ClientError as e:
+                            print(f"Error downloading {s3_key}: {e}")
+                            return False  # Return False on any download error
+
+        if not downloaded_something:
+            print(f"No files found in S3 folder '{s3_folder}' within bucket '{bucket_name}'.")
+            return True # return true, since technically the download was successful - no downloads were needed
+
+        return True  # Return True if everything was downloaded successfully
+
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "NoSuchBucket":
+            print(f"Error: The bucket '{bucket_name}' does not exist.")
+        else:
+            print(f"Error accessing S3: {e}")
+        return False
+    except botocore.exceptions.NoCredentialsError:
+        print("Error: No AWS credentials found.")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+def download_s3_file(bucket_name, region_name, s3_file_key, local_dir, aws_access_key_id=None, aws_secret_access_key=None):
+
+    try:
+        # Create an S3 client.  Prioritize explicit credentials, then profile, then environment/IAM.
+        if aws_access_key_id and aws_secret_access_key:
+            s3 = boto3.client('s3', aws_access_key_id=aws_access_key_id,
+                              aws_secret_access_key=aws_secret_access_key,
+                              region_name=region_name)
+        else:
+             # Use UNSIGNED credentials (environment variables, IAM role, etc.)
+            s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+
+        # split filepath to include everything after "Robots/"
+        filepath_after_robots = s3_file_key.split("Robots/")[1]
+
+        # append file name to local_dir
+        local_target_filepath = os.path.join(local_dir, filepath_after_robots)
+
+        # Create necessary directories
+        os.makedirs(os.path.dirname(local_target_filepath), exist_ok=True)
+
+        # Download the file
+        s3.download_file(bucket_name, s3_file_key, local_target_filepath)
+        print(f"File '{s3_file_key}' downloaded from bucket '{bucket_name}' to '{local_target_filepath}'")
+        return True
+
+
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "404":
+            print(f"Error: The object '{s3_file_key}' does not exist in bucket '{bucket_name}'.")
+        elif e.response['Error']['Code'] == "403":
+            print(f"Error: Access denied to '{s3_file_key}' in bucket '{bucket_name}'. Check your permissions.")
+        else:
+            print(f"Error downloading file from S3: {e}")
+        return False
+    except botocore.exceptions.NoCredentialsError:
+        print("Error: No AWS credentials found.  Please configure your credentials.")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+
+if __name__ == '__main__':
+
+    robot_cfg = RobotAssetBucketCfg()
+    if download_s3_file(
+        robot_cfg.bucket_name,
+        robot_cfg.region_name,
+        robot_cfg.s3_folder_path,
+        robot_cfg.target_local_path
+    ):
+        print("Robot asset download successful.")
+
+    world_cfg = WorldAssetBucketCfg()
+    if download_s3_folder(
+        world_cfg.bucket_name,
+        world_cfg.region_name,
+        world_cfg.s3_folder_path,
+        world_cfg.target_local_path,
+        aws_access_key_id=world_cfg.my_access_key_ID,
+        aws_secret_access_key=world_cfg.my_secret_key
+    ):
+        print("World asset download successful.")

--- a/source/groundcontrol_assets/groundcontrol_assets/__init__.py
+++ b/source/groundcontrol_assets/groundcontrol_assets/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -25,4 +26,5 @@ __version__ = GROUNDCONTROL_ASSETS_METADATA["package"]["version"]
 ##
 # Configuration for different assets.
 ##
-from .spot import *
+#from .robots import *
+#from .worlds import *

--- a/source/groundcontrol_assets/groundcontrol_assets/robots/__init__.py
+++ b/source/groundcontrol_assets/groundcontrol_assets/robots/__init__.py
@@ -3,3 +3,8 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
+
+##
+# Configuration for different assets.
+##
+from .spot import *

--- a/source/groundcontrol_assets/groundcontrol_assets/robots/spot.py
+++ b/source/groundcontrol_assets/groundcontrol_assets/robots/spot.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -12,6 +13,7 @@ The following configuration parameters are available:
 """
 
 import torch
+import os
 
 # Note: These are imported from Isaac Lab, not GroundControl. If you customize them, ensure you are importing
 # from the child (GroundControl)
@@ -21,6 +23,7 @@ from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 # ===== NOTE:IsaacLab imports === ^^^ 
 # ===== GroundControl imports === VVV
+from groundcontrol_assets import GROUNDCONTROL_ASSETS_DATA_DIR
 
 # Note: This data was collected by the Boston Dynamics AI Institute.
 joint_parameter_lookup = torch.tensor([
@@ -136,10 +139,20 @@ and the output torque (N*m). It is used to interpolate the output torque based o
 # Configuration
 ##
 
+def is_missing_robot_USD_file():
+    """Check if the world USD file is missing."""
+    spot_path = os.path.join(GROUNDCONTROL_ASSETS_DATA_DIR, "Robots", "BostonDynamics", "spot", "spot.usd")
+    return not os.path.exists(spot_path)
+
+if is_missing_robot_USD_file():
+    raise FileNotFoundError(
+        "Robot USD file is missing. Please run 'python scripts/update_assets' to download the file."
+    )
 
 SPOT_CFG = ArticulationCfg(
     spawn=sim_utils.UsdFileCfg(
         usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/BostonDynamics/spot/spot.usd",
+        #usd_path=f"{GROUNDCONTROL_ASSETS_DATA_DIR}/Robots/BostonDynamics/spot/spot.usd", # TODO: swap to this if "GC_LOCAL_DATA" set
         activate_contact_sensors=True,
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
             disable_gravity=False,

--- a/source/groundcontrol_assets/groundcontrol_assets/worlds/__init__.py
+++ b/source/groundcontrol_assets/groundcontrol_assets/worlds/__init__.py
@@ -3,3 +3,8 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
+
+##
+# Configuration for different assets.
+##
+from .gracesquarters import *

--- a/source/groundcontrol_assets/groundcontrol_assets/worlds/gracesquarters.py
+++ b/source/groundcontrol_assets/groundcontrol_assets/worlds/gracesquarters.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+"""Configuration for the GracesQuarters USD-based terrain and map.
+
+"""
+
+import os
+# ===== NOTE:IsaacLab imports === ^^^ 
+# ===== GroundControl imports === VVV
+from groundcontrol_assets import GROUNDCONTROL_ASSETS_DATA_DIR
+
+def is_missing_world_USD_file():
+    """Check if the world USD file is missing."""
+    graces_quarters_path = os.path.join(GROUNDCONTROL_ASSETS_DATA_DIR, "Worlds", "Collected_GQ_lite", "GQ_lite.usd")
+    return not os.path.exists(graces_quarters_path)

--- a/source/groundcontrol_assets/setup.py
+++ b/source/groundcontrol_assets/setup.py
@@ -8,6 +8,13 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
+# Minimum dependencies required prior to installation
+INSTALL_REQUIRES = [
+    "boto3",
+    "botocore",
+    "huggingface_hub",
+]
+
 # Installation operation
 setup(
     name="groundcontrol_assets",

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/agents/rsl_rl_ppo_cfg.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/agents/rsl_rl_ppo_cfg.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
@@ -26,7 +26,7 @@ from groundcontrol_tasks.manager_based.locomotion.velocity.velocity_env_cfg impo
 ##
 # Pre-defined configs
 ##
-from isaaclab_assets.robots.spot import SPOT_CFG  # isort: skip
+from groundcontrol_assets.robots.spot import SPOT_CFG  # isort: skip
 
 
 COBBLESTONE_ROAD_CFG = terrain_gen.TerrainGeneratorCfg(

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/mdp/__init__.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/mdp/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/mdp/events.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/mdp/events.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/mdp/rewards.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/config/spot/mdp/rewards.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The GroundControl Project Developers.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
@@ -31,6 +31,7 @@ from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort: skip
 
 # ===== NOTE:IsaacLab imports === ^^^ 
 # ===== GroundControl imports === VVV
+from groundcontrol_assets import GROUNDCONTROL_ASSETS_DATA_DIR
 import groundcontrol_tasks.manager_based.locomotion.velocity.mdp as mdp
 
 
@@ -80,7 +81,7 @@ class MySceneCfg(InteractiveSceneCfg):
         prim_path="/World/skyLight",
         spawn=sim_utils.DomeLightCfg(
             intensity=750.0,
-            texture_file=f"{ISAAC_NUCLEUS_DIR}/Materials/Textures/Skies/PolyHaven/kloofendal_43d_clear_puresky_4k.hdr",
+            texture_file=f"{GROUNDCONTROL_ASSETS_DATA_DIR}/Materials/Textures/Skies/PolyHaven/kloofendal_43d_clear_puresky_4k.hdr",
         ),
     )
 

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/navigation/config/spot/navigation_env_cfg.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/navigation/config/spot/navigation_env_cfg.py
@@ -20,7 +20,8 @@ from isaaclab.sensors.camera.camera_cfg import PinholeCameraCfg
 
 # ===== NOTE:IsaacLab imports === ^^^ 
 # ===== GroundControl imports === VVV
-from groundcontrol import GROUNDCONTROL_EXT_DIR
+from groundcontrol_assets import GROUNDCONTROL_ASSETS_DATA_DIR
+from groundcontrol_assets.worlds.gracesquarters import is_missing_world_USD_file
 import groundcontrol_tasks.manager_based.navigation.mdp as mdp
 from groundcontrol_tasks.manager_based.locomotion.velocity.config.spot.flat_env_cfg import SpotFlatEnvCfg
 from groundcontrol.sensors.camera import TiledCameraCfg #TODO: migrate to IsaacLab cameras when ready
@@ -88,6 +89,7 @@ class ObservationsCfg:
         # TODO: add more cameras later
         # TODO: note that cameras are not within HighLevelPolicyCfg, this is because the policy does not depend on camera atm 
         # TODO: these cameras do not need to be in the ObservationCfg for them to be accessed in the GUI, the only need to be in self.scene
+
     # observation groups
     policy: HighlevelPolicyCfg = HighlevelPolicyCfg()
     perception: PerceptionCfg = PerceptionCfg()
@@ -203,8 +205,17 @@ class NavigationEnvCfg(SpotFlatEnvCfg):
 @configclass
 class NavigationEnvCfg_PLAY(NavigationEnvCfg):
     def __post_init__(self) -> None:
+
+        if is_missing_world_USD_file():
+            raise FileNotFoundError(
+                "World USD file is missing. Please run 'python scripts/update_assets' to download the file."
+            )
+
         # post init of parent
         super().__post_init__()
+
+        # set debug in aciton policy to false
+        self.actions.pre_trained_policy_action.debug_vis = False
 
         # make a smaller scene for play
         self.scene.num_envs = 50
@@ -224,7 +235,7 @@ class NavigationEnvCfg_PLAY(NavigationEnvCfg):
                 pos=(0,0,-5)
             ),
             spawn=sim_utils.UsdFileCfg(
-                usd_path="/home/simdev/WRK/00_USD/Collected_GQ_lite/GQ_lite.usd",
+                usd_path=f"{GROUNDCONTROL_ASSETS_DATA_DIR}/Worlds/Collected_GQ_lite/GQ_lite.usd",
                 scale=(0.01, 0.01, 0.01),
                 rigid_props=sim_utils.RigidBodyPropertiesCfg(
                     kinematic_enabled=True,

--- a/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
+++ b/source/groundcontrol_tasks/groundcontrol_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import torch
-from dataclasses import MISSING, dataclass
 from typing import TYPE_CHECKING
 from huggingface_hub import hf_hub_download
 
@@ -44,8 +43,11 @@ class PreTrainedPolicyAction(ActionTerm):
         self.robot: Articulation = env.scene[cfg.asset_name]
 
         # load policy
-        file_from_hf = hf_hub_download(repo_id=cfg.policy_path, filename="policy.pt")
-        file_bytes = read_file(file_from_hf)
+        try:
+            file_from_hf = hf_hub_download(repo_id=cfg.policy_path, filename="policy.pt")
+            file_bytes = read_file(file_from_hf)
+        except:
+            raise ValueError(f"Failed to download policy from {cfg.policy_path}.")
 
         # This is the Low-Level Policy which is being controlled by the Upper-Level Policy
         self.policy = torch.jit.load(file_bytes).to(env.device).eval()


### PR DESCRIPTION
This adds the ability to download:
1. Robot assets
2. World assets
3. (WIP) other misc prop assets

to local data directory.

We use boto3 for pulling files from AWS bucket programatically.

Please see `scripts/update_assets.py`. 